### PR TITLE
Respond to enquire_link PDU from SMSC

### DIFF
--- a/AberrantSMPP/Utility/PduFactory.cs
+++ b/AberrantSMPP/Utility/PduFactory.cs
@@ -122,6 +122,9 @@ namespace AberrantSMPP.Utility
 				case CommandId.deliver_sm:
 					packet = new SmppDeliverSm(response);
 					break;
+				case CommandId.enquire_link:
+					packet = new SmppEnquireLink(response);
+					break;
 				case CommandId.enquire_link_resp:
 					packet = new SmppEnquireLinkResp(response);
 					break;


### PR DESCRIPTION
Some SMSC:s requires ESME:s to respond to enquire_link-requests. The code for sending the response was already in the repository. This PR merely makes the PDU factory instantiate the request object.
